### PR TITLE
Implement map

### DIFF
--- a/inc/order/lib.h
+++ b/inc/order/lib.h
@@ -8,3 +8,4 @@
 #include "order/lib/limits.h"
 #include "order/lib/params.h"
 #include "order/lib/stream.h"
+#include "order/lib/collections.h"

--- a/inc/order/lib/collections.h
+++ b/inc/order/lib/collections.h
@@ -1,0 +1,4 @@
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.)
+
+#include "order/lib/collections/map.h"

--- a/inc/order/lib/collections/map.h
+++ b/inc/order/lib/collections/map.h
@@ -6,7 +6,11 @@
 
 // First-order
 
-#define ORDER_PP_DEF_8map(cmp, ...) 8EVAL_MAP,cmp,ORDER_PP_SEQ_AT_0 __VA_ARGS__(0map_eval_terminate,),
+#define ORDER_PP_DEF_8map(...) 8EVAL_MAP,ORDER_PP_0EVAL_MAP_ARGS(__VA_ARGS__)(0map_eval_terminate,),
+
+#define ORDER_PP_0EVAL_MAP_ARGS(...) ORDER_PP_OVERLOAD(0EVAL_MAP_ARGS, ORDER_PP_IS_TUPLE_SIZE_1(,__VA_ARGS__)(,1,N))(__VA_ARGS__)
+#define ORDER_PP_0EVAL_MAP_ARGS_1(cmp) cmp,ORDER_PP_SEQ_AT_0
+#define ORDER_PP_0EVAL_MAP_ARGS_N(cmp, ...) cmp,ORDER_PP_SEQ_AT_0 __VA_ARGS__
 
 #define ORDER_PP_8EVAL_MAP(P, env, q_cmp, q_head_key, q_head_value, tail, G, ...) \
                           (,P##env,ORDER_PP_DEF_##q_cmp,8EVAL_MAP_LOOP,P##q_head_key,P##q_head_value,P##tail,,P##env,P##__VA_ARGS__)
@@ -27,7 +31,7 @@
 
 
 #define ORDER_PP_DEF_8map_items ORDER_PP_FN_NATIVE(1,8MAP_ITEMS,0IS_MAP)
-#define ORDER_PP_8MAP_ITEMS(P, map, ...) ORDER_PP_FX(TUPLE_AT_1,(,ORDER_PP_REM P##map,))
+#define ORDER_PP_8MAP_ITEMS(P, map) ORDER_PP_FX(TUPLE_AT_1,(,ORDER_PP_REM P##map,))
 
 
 #define ORDER_PP_DEF_8map_keys ORDER_PP_FN(8fn(8M, 8seq_map(8tuple_at_0, 8map_items(8M))))
@@ -113,7 +117,7 @@ ORDER_PP_FN(8fn(8M, 8N, \
 
 
 #define ORDER_PP_DEF_8seq_of_pairs_to_map ORDER_PP_FN_NATIVE(2,8SEQ_OF_PAIRS_TO_MAP,0IS_FN,0IS_ANY)
-#define ORDER_PP_8SEQ_OF_PAIRS_TO_MAP(P, cmp, items) (P##cmp, P##items)
+#define ORDER_PP_8SEQ_OF_PAIRS_TO_MAP(P, cmp, items) (P##cmp,P##items)
 
 // Detail
 #define ORDER_PP_0IS_MAP(P,x) ORDER_PP_AND                                                                  \

--- a/inc/order/lib/collections/map.h
+++ b/inc/order/lib/collections/map.h
@@ -59,8 +59,17 @@ ORDER_PP_FN(8fn(8K, 8M,                                                         
 #define ORDER_PP_DEF_8map_insert \
 ORDER_PP_FN(8fn(8K, 8V, 8M, \
                 8if(8map_exists(8K, 8M), \
-                    8M, \
+                    8map_replace(8K, 8V, 8M), \
                     0map_reset(8seq_push_back(8pair(8K, 8V), 8map_items(8M)), 8M))))
+
+
+#define ORDER_PP_DEF_8map_replace \
+ORDER_PP_FN(8fn(8K, 8V, 8M, \
+                0map_reset(8seq_map(8fn(8E, \
+                                        8if(0map_item_matches(8E, 8K, 8M), \
+                                            8pair(8K, 8V), \
+                                            8E)), \
+                                    8map_items(8M)), 8M)))
 
 
 #define ORDER_PP_DEF_8map_erase \

--- a/inc/order/lib/map.h
+++ b/inc/order/lib/map.h
@@ -6,23 +6,20 @@
 
 // First-order
 
-#define ORDER_PP_DEF_8map(cmp, ...) 8EVAL_MAP,ORDER_PP_SEQ_AT_0 __VA_ARGS__(0map_eval_terminate,),cmp,
+#define ORDER_PP_DEF_8map(cmp, ...) 8EVAL_MAP,cmp,ORDER_PP_SEQ_AT_0 __VA_ARGS__(0map_eval_terminate,),
 
-#define ORDER_PP_8EVAL_MAP(P, env, q_head_key, q_head_value, tail, cmp, G, ...) \
-                          (,P##env,8EVAL_MAP_LOOP,P##q_head_key,P##q_head_value,P##tail,,P##cmp,P##__VA_ARGS__)
-#define ORDER_PP_8EVAL_MAP_LOOP(P, env, q_head_key, q_head_value, tail, acc, cmp, ...) \
+#define ORDER_PP_8EVAL_MAP(P, env, q_cmp, q_head_key, q_head_value, tail, G, ...) \
+                          (,P##env,ORDER_PP_DEF_##q_cmp,8EVAL_MAP_LOOP,P##q_head_key,P##q_head_value,P##tail,,P##env,P##__VA_ARGS__)
+#define ORDER_PP_8EVAL_MAP_LOOP(P, cmp, q_head_key, q_head_value, tail, acc, env, ...) \
                                (,P##env,ORDER_PP_DEF_##q_head_key,8EVAL_MAP_LOOP_B,P##q_head_value,P##tail,P##acc,P##cmp,P##env,P##__VA_ARGS__)
 #define ORDER_PP_8EVAL_MAP_LOOP_B(P, head_key, q_head_value, tail, acc, cmp, env, ...) \
                                  (,P##env,ORDER_PP_DEF_##q_head_value,8EVAL_MAP_LOOP_C,P##head_key,P##tail,P##acc,P##cmp,P##env,P##__VA_ARGS__)
 #define ORDER_PP_8EVAL_MAP_LOOP_C(P, head_value, head_key, tail, acc, cmp, env, ...) \
-                                 (,P##env,8EVAL_MAP_LOOP,ORDER_PP_SEQ_AT_0 tail##P,P##acc(P##head_key,P##head_value),P##cmp,P##__VA_ARGS__)
+                                 (,P##cmp,8EVAL_MAP_LOOP,ORDER_PP_SEQ_AT_0 tail##P,P##acc(P##head_key,P##head_value),P##env,P##__VA_ARGS__)
 
 #define ORDER_PP_DEF_0map_eval_terminate 0EVAL_MAP_TERMINATE,
-
 #define ORDER_PP_0EVAL_MAP_TERMINATE(P, env, G, _eval_map_loop_b_, _q_head_value_, _tail_, _acc_, _cmp_, _env_,...) \
-                                    (,P##env,ORDER_PP_DEF_##_cmp_, 0EVAL_MAP_TERMINATE_B, P##_acc_, __VA_ARGS__)   
-#define ORDER_PP_0EVAL_MAP_TERMINATE_B(P, cmp, acc, ...) \
-                                      (,(P##cmp,ORDER_PP_9VSEQ_TO_SEQ_OF_TUPLES(,P##acc)),__VA_ARGS__)
+                                    (,(P##_cmp_,ORDER_PP_9VSEQ_TO_SEQ_OF_TUPLES(,P##_acc_)), __VA_ARGS__)   
 
 
 #define ORDER_PP_DEF_8map_equivalence_fn ORDER_PP_FN_CM(1,8MAP_EQUIVALENCE_FN,0IS_MAP)

--- a/inc/order/lib/map.h
+++ b/inc/order/lib/map.h
@@ -19,21 +19,21 @@
 
 #define ORDER_PP_DEF_0map_eval_terminate 0EVAL_MAP_TERMINATE,
 #define ORDER_PP_0EVAL_MAP_TERMINATE(P, env, G, _eval_map_loop_b_, _q_head_value_, _tail_, _acc_, _cmp_, _env_,...) \
-                                    (,(P##_cmp_,ORDER_PP_9VSEQ_TO_SEQ_OF_TUPLES(,P##_acc_)), __VA_ARGS__)   
+                                    (,(P##_cmp_,ORDER_PP_9VSEQ_TO_SEQ_OF_TUPLES(,P##_acc_)), P##__VA_ARGS__)   
 
 
-#define ORDER_PP_DEF_8map_equivalence_fn ORDER_PP_FN_CM(1,8MAP_EQUIVALENCE_FN,0IS_MAP)
-#define ORDER_PP_8MAP_EQUIVALENCE_FN(P, map, ...) (,ORDER_PP_FX(TUPLE_AT_0,(,ORDER_PP_REM P##map,)),__VA_ARGS__)
+#define ORDER_PP_DEF_8map_equivalence_fn ORDER_PP_FN_NATIVE(1,8MAP_EQUIVALENCE_FN,0IS_MAP)
+#define ORDER_PP_8MAP_EQUIVALENCE_FN(P, map) ORDER_PP_FX(TUPLE_AT_0,(,ORDER_PP_REM P##map,))
 
 
-#define ORDER_PP_DEF_8map_items ORDER_PP_FN_CM(1,8MAP_ITEMS,0IS_MAP)
-#define ORDER_PP_8MAP_ITEMS(P, map, ...) (,ORDER_PP_FX(TUPLE_AT_1,(,ORDER_PP_REM P##map,)),__VA_ARGS__)
+#define ORDER_PP_DEF_8map_items ORDER_PP_FN_NATIVE(1,8MAP_ITEMS,0IS_MAP)
+#define ORDER_PP_8MAP_ITEMS(P, map, ...) ORDER_PP_FX(TUPLE_AT_1,(,ORDER_PP_REM P##map,))
 
 
-#define ORDER_PP_DEF_8map_keys ORDER_PP_FN(8fn(8M, 8seq_map(8fn(8E, 8tuple_at_0(8E)), 8map_items(8M))))
+#define ORDER_PP_DEF_8map_keys ORDER_PP_FN(8fn(8M, 8seq_map(8tuple_at_0, 8map_items(8M))))
 
 
-#define ORDER_PP_DEF_8map_values ORDER_PP_FN(8fn(8M, 8seq_map(8fn(8E, 8tuple_at_1(8E)), 8map_items(8M))))
+#define ORDER_PP_DEF_8map_values ORDER_PP_FN(8fn(8M, 8seq_map(8tuple_at_1, 8map_items(8M))))
 
 
 #define ORDER_PP_DEF_8map_at                                                                            \

--- a/inc/order/lib/map.h
+++ b/inc/order/lib/map.h
@@ -56,16 +56,15 @@ ORDER_PP_FN(8fn(8K, 8M,                                                         
 ORDER_PP_FN(8fn(8K, 8V, 8M, \
                 8if(8map_exists(8K, 8M), \
                     8M, \
-                    8seq_of_pairs_to_map(8map_equivalence_fn(8M), \
-                                         8seq_push_back(8pair(8K, 8V), 8map_items(8M))))))
+                    0map_reset(8seq_push_back(8pair(8K, 8V), 8map_items(8M)), 8M))))
 
 
 #define ORDER_PP_DEF_8map_erase \
 ORDER_PP_FN(8fn(8K, 8M, \
-                8seq_of_pairs_to_map(8map_equivalence_fn(8M), \
-                                     8seq_filter(8fn(8E, \
-                                                     8not(0map_item_matches(8E, 8K, 8M))), \
-                                                 8map_items(8M)))))
+                0map_reset(8seq_filter(8fn(8E, \
+                                           8not(0map_item_matches(8E, 8K, 8M))), \
+                                       8map_items(8M)), \
+                           8M)))
 
 
 #define ORDER_PP_DEF_8map_size ORDER_PP_FN(8fn(8M, 8seq_size(8map_items(8M))))
@@ -76,6 +75,43 @@ ORDER_PP_FN(8fn(8K, 8M, \
 
 // Higher-order
 
+#define ORDER_PP_DEF_8map_union \
+ORDER_PP_FN(8fn(8M, 8N, \
+                8seq_fold(8fn(8A, 8E, \
+                              8map_insert(8tuple_at_0(8E), 8tuple_at_1(8E), 8A)), \
+                          8M, 8map_items(8N))))
+
+
+#define ORDER_PP_DEF_8map_intersect \
+ORDER_PP_FN(8fn(8M, 8N, \
+                0map_reset(8seq_fold(8fn(8A, 8E, \
+                                         8if(8map_exists(8tuple_at_0(8E), 8N), \
+                                             8seq_push_back(8E, 8A), \
+                                             8A)), \
+                                     8nil, 8map_items(8M)), \
+                           8M)))
+
+
+#define ORDER_PP_DEF_8map_diff \
+ORDER_PP_FN(8fn(8M, 8N, \
+                0map_reset(8seq_fold(8fn(8A, 8E, \
+                                         8if(8map_exists(8tuple_at_0(8E), 8N), \
+                                             8A, \
+                                             8seq_push_back(8E, 8A))), \
+                                     8nil, 8map_items(8M)), \
+                           8M)))
+
+
+#define ORDER_PP_DEF_8map_symm_diff \
+ORDER_PP_FN(8fn(8M, 8N, \
+                0map_reset(8seq_fold(8fn(8A, 8E, \
+                                         8if(8map_exists(8tuple_at_0(8E), 8N), \
+                                         8seq_filter(8fn(8U, 8not(0map_item_matches(8U, 8tuple_at_0(8E), 8N))), 8A), \
+                                         8seq_push_back(8E, 8A))), \
+                                     8map_items(8N), 8map_items(8M)), \
+                           8M)))
+
+
 #define ORDER_PP_DEF_8seq_of_pairs_to_map ORDER_PP_FN_NATIVE(2,8SEQ_OF_PAIRS_TO_MAP,0IS_FN,0IS_ANY)
 #define ORDER_PP_8SEQ_OF_PAIRS_TO_MAP(P, cmp, items) (P##cmp, P##items)
 
@@ -85,8 +121,8 @@ ORDER_PP_FN(8fn(8K, 8M, \
                               (and)(ORDER_PP_FY(IS_TUPLE_SIZE_2,(,ORDER_PP_REM P##x)))                      \
                               (and)(ORDER_PP_FY(0IS_FN,(,ORDER_PP_FX(TUPLE_AT_0,(,ORDER_PP_REM P##x,)))))()
 
-#define ORDER_PP_DEF_0map_item_matches \
-ORDER_PP_FN(8fn(8E, 8K, 8M, \
-                8ap(8map_equivalence_fn(8M), 8K, 8tuple_at_0(8E))))
+#define ORDER_PP_DEF_0map_item_matches(entry, key, map) ORDER_PP_MACRO(8ap(8map_equivalence_fn(map), key, 8tuple_at_0(entry)))
+
+#define ORDER_PP_DEF_0map_reset(items, map) ORDER_PP_MACRO(8seq_of_pairs_to_map(8map_equivalence_fn(map), items))
 
 #endif

--- a/inc/order/lib/map.h
+++ b/inc/order/lib/map.h
@@ -54,14 +54,18 @@ ORDER_PP_FN(8fn(8K, 8M,                                                         
 
 #define ORDER_PP_DEF_8map_insert \
 ORDER_PP_FN(8fn(8K, 8V, 8M, \
-                8pair(8map_equivalence_fn(8M), \
-                      8seq_push_back(8pair(8K, 8V), 8map_items(8M)))))
+                8if(8map_exists(8K, 8M), \
+                    8M, \
+                    8seq_of_pairs_to_map(8map_equivalence_fn(8M), \
+                                         8seq_push_back(8pair(8K, 8V), 8map_items(8M))))))
 
 
 #define ORDER_PP_DEF_8map_erase \
 ORDER_PP_FN(8fn(8K, 8M, \
-                8pair(8map_equivalence_fn(8M), \
-                      8seq_filter(8fn(8E, 8not(0map_item_matches(8E, 8K, 8M))), 8map_items(8M)))))
+                8seq_of_pairs_to_map(8map_equivalence_fn(8M), \
+                                     8seq_filter(8fn(8E, \
+                                                     8not(0map_item_matches(8E, 8K, 8M))), \
+                                                 8map_items(8M)))))
 
 
 #define ORDER_PP_DEF_8map_size ORDER_PP_FN(8fn(8M, 8seq_size(8map_items(8M))))

--- a/inc/order/lib/map.h
+++ b/inc/order/lib/map.h
@@ -1,0 +1,86 @@
+#ifndef ORDER_INC_ORDER_LIB_MAP_H
+#define ORDER_INC_ORDER_LIB_MAP_H
+
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.)
+
+// First-order
+
+#define ORDER_PP_DEF_8map(cmp, ...) 8EVAL_MAP,ORDER_PP_SEQ_AT_0 __VA_ARGS__(0map_eval_terminate,),cmp,
+
+#define ORDER_PP_8EVAL_MAP(P, env, q_head_key, q_head_value, tail, cmp, G, ...) \
+                          (,P##env,8EVAL_MAP_LOOP,P##q_head_key,P##q_head_value,P##tail,,P##cmp,P##__VA_ARGS__)
+#define ORDER_PP_8EVAL_MAP_LOOP(P, env, q_head_key, q_head_value, tail, acc, cmp, ...) \
+                               (,P##env,ORDER_PP_DEF_##q_head_key,8EVAL_MAP_LOOP_B,P##q_head_value,P##tail,P##acc,P##cmp,P##env,P##__VA_ARGS__)
+#define ORDER_PP_8EVAL_MAP_LOOP_B(P, head_key, q_head_value, tail, acc, cmp, env, ...) \
+                                 (,P##env,ORDER_PP_DEF_##q_head_value,8EVAL_MAP_LOOP_C,P##head_key,P##tail,P##acc,P##cmp,P##env,P##__VA_ARGS__)
+#define ORDER_PP_8EVAL_MAP_LOOP_C(P, head_value, head_key, tail, acc, cmp, env, ...) \
+                                 (,P##env,8EVAL_MAP_LOOP,ORDER_PP_SEQ_AT_0 tail##P,P##acc(P##head_key,P##head_value),P##cmp,P##__VA_ARGS__)
+
+#define ORDER_PP_DEF_0map_eval_terminate 0EVAL_MAP_TERMINATE,
+
+#define ORDER_PP_0EVAL_MAP_TERMINATE(P, env, G, _eval_map_loop_b_, _q_head_value_, _tail_, _acc_, _cmp_, _env_,...) \
+                                    (,P##env,ORDER_PP_DEF_##_cmp_, 0EVAL_MAP_TERMINATE_B, P##_acc_, __VA_ARGS__)   
+#define ORDER_PP_0EVAL_MAP_TERMINATE_B(P, cmp, acc, ...) \
+                                      (,(P##cmp,ORDER_PP_9VSEQ_TO_SEQ_OF_TUPLES(,P##acc)),__VA_ARGS__)
+
+
+#define ORDER_PP_DEF_8map_equivalence_fn ORDER_PP_FN_CM(1,8MAP_EQUIVALENCE_FN,0IS_MAP)
+#define ORDER_PP_8MAP_EQUIVALENCE_FN(P, map, ...) (,ORDER_PP_FX(TUPLE_AT_0,(,ORDER_PP_REM P##map,)),__VA_ARGS__)
+
+
+#define ORDER_PP_DEF_8map_items ORDER_PP_FN_CM(1,8MAP_ITEMS,0IS_MAP)
+#define ORDER_PP_8MAP_ITEMS(P, map, ...) (,ORDER_PP_FX(TUPLE_AT_1,(,ORDER_PP_REM P##map,)),__VA_ARGS__)
+
+
+#define ORDER_PP_DEF_8map_keys ORDER_PP_FN(8fn(8M, 8seq_map(8fn(8E, 8tuple_at_0(8E)), 8map_items(8M))))
+
+
+#define ORDER_PP_DEF_8map_values ORDER_PP_FN(8fn(8M, 8seq_map(8fn(8E, 8tuple_at_1(8E)), 8map_items(8M))))
+
+
+#define ORDER_PP_DEF_8map_at                                                                            \
+ORDER_PP_FN(8fn(8K, 8M,                                                                                 \
+                8call_cc(8fn(8C,                                                                        \
+                             8seq_for_each(8fn(8E,                                                      \
+                                               8when(0map_item_matches(8E, 8K, 8M), \
+                                                     8ap(8C, 8tuple_at_1(8E)))),                        \
+                                           8map_items(8M))))))
+
+
+#define ORDER_PP_DEF_8map_exists                                                        \
+ORDER_PP_FN(8fn(8K, 8M,                                                                 \
+                8seq_exists(8fn(8E, \
+                                0map_item_matches(8E, 8K, 8M)), \
+                            8map_items(8M))))
+
+
+#define ORDER_PP_DEF_8map_insert \
+ORDER_PP_FN(8fn(8K, 8V, 8M, \
+                8pair(8map_equivalence_fn(8M), \
+                      8seq_push_back(8pair(8K, 8V), 8map_items(8M)))))
+
+
+#define ORDER_PP_DEF_8map_erase \
+ORDER_PP_FN(8fn(8K, 8M, \
+                8pair(8map_equivalence_fn(8M), \
+                      8seq_filter(8fn(8E, 8not(0map_item_matches(8E, 8K, 8M))), 8map_items(8M)))))
+
+
+#define ORDER_PP_DEF_8map_size ORDER_PP_FN(8fn(8M, 8seq_size(8map_items(8M))))
+
+
+#define ORDER_PP_DEF_8is_map ORDER_PP_FN_CM(1,8IS_MAP,0IS_ANY)
+#define ORDER_PP_8IS_MAP(P,x,...) (,ORDER_PP_0IS_MAP(,P##x)(,8true,8false),P##__VA_ARGS__)
+
+// Detail
+#define ORDER_PP_0IS_MAP(P,x) ORDER_PP_AND                                                                  \
+                              (and)(ORDER_PP_0IS_TUPLE(,P##x))                                              \
+                              (and)(ORDER_PP_FY(IS_TUPLE_SIZE_2,(,ORDER_PP_REM P##x)))                      \
+                              (and)(ORDER_PP_FY(0IS_FN,(,ORDER_PP_FX(TUPLE_AT_0,(,ORDER_PP_REM P##x,)))))()
+
+#define ORDER_PP_DEF_0map_item_matches \
+ORDER_PP_FN(8fn(8E, 8K, 8M, \
+                8ap(8map_equivalence_fn(8M), 8K, 8tuple_at_0(8E))))
+
+#endif

--- a/inc/order/lib/map.h
+++ b/inc/order/lib/map.h
@@ -73,6 +73,11 @@ ORDER_PP_FN(8fn(8K, 8M, \
 #define ORDER_PP_DEF_8is_map ORDER_PP_FN_CM(1,8IS_MAP,0IS_ANY)
 #define ORDER_PP_8IS_MAP(P,x,...) (,ORDER_PP_0IS_MAP(,P##x)(,8true,8false),P##__VA_ARGS__)
 
+// Higher-order
+
+#define ORDER_PP_DEF_8seq_of_pairs_to_map ORDER_PP_FN_NATIVE(2,8SEQ_OF_PAIRS_TO_MAP,0IS_FN,0IS_ANY)
+#define ORDER_PP_8SEQ_OF_PAIRS_TO_MAP(P, cmp, items) (P##cmp, P##items)
+
 // Detail
 #define ORDER_PP_0IS_MAP(P,x) ORDER_PP_AND                                                                  \
                               (and)(ORDER_PP_0IS_TUPLE(,P##x))                                              \

--- a/test/test.db
+++ b/test/test.db
@@ -399,6 +399,7 @@
 8to_lit(8map_size(8map(8equal,(1,2)(8add(2,3),10)(8,20))))#3#
 8map_keys(8map(8equal,(1,2)(8add(2,3),10)(8,20)))#(1)(5)(8)#
 8map_values(8map(8equal,(1,2)(8add(2,3),10)(8,20)))#(2)(10)(20)#
-8map_items(8map_union(8map(8equal,(1,2)(3,4)(5,6)),8map(8equal,(1,22)(3,44)(5,66)(7, 88))))#((1,2))((3,4))((5,6))((7,88))#
-8map_items(8map_intersect(8map(8equal,(0,0)(1,2)(3,4)(5,6)),8map(8equal,(1,22)(3,44)(5,66)(7, 88))))#((1,2))((3,4))((5,6))#
-8map_items(8map_symm_diff(8map(8equal,(0,0)(1,2)(3,4)(5,6)),8map(8equal,(1,22)(3,44)(5,66)(7, 88))))#((7,88))((0,0))#
+8map_items(8map_insert(5, 10, 8map(8equal)))#((5,10))#
+8map_items(8map_insert(5,20,8map_insert(5,10,8map(8equal))))#((5,20))#
+8map_items(8map_symm_diff(8map(8equal,(0,0)(1,2)(3,4)(5,6)),8map(8equal,(1,22)(3,44)(5,66)(7,88))))#((7,88))((0,0))#
+8map_items(8map_intersect(8map(8equal,(0,0)(1,2)(3,4)(5,6)),8map(8equal,(1,22)(3,44)(5,66)(7,88))))#((1,2))((3,4))((5,6))#

--- a/test/test.db
+++ b/test/test.db
@@ -388,3 +388,17 @@
 8while(8greater(8),8plus(2),0)#8#
 8with_assert(8and(8true,8false),8add(5,6))#ORDER_PP_ASSERTION_FAILURE:8with_assert(8and ( 8true , 8false ),8add ( 5 , 6 )):(,8EXIT,,)#ORDER_PP_ASSERTION_FAILURE
 8with_assert(8or(8false,8true),8put(1),8put(2),3)#1 2 3#
+8map_items(8map(8equal))##
+8map_items(8map(8equal,(1,2)(3,4)))#((1,2))((3,4))#
+8map_items(8map(8equal,(8add(2,3),10)))#((5,10))#
+8is_map(8map(8equal))#8true#
+8map_exists(7,8map(8equal,(8add(5,2), 10)))#8true#
+8map_exists(8,8map(8equal,(8add(5,2), 10)))#8false#
+8map_equivalence_fn(8map(8equal))#(,8NATIVE,1,9EQUAL,(,0IS_NUM,0IS_NUM,))#
+8map_items(8map(8equal,(1,2)(8add(2,3),10)(8,20)))#((1,2))((5,10))((8,20))#
+8to_lit(8map_size(8map(8equal,(1,2)(8add(2,3),10)(8,20))))#3#
+8map_keys(8map(8equal,(1,2)(8add(2,3),10)(8,20)))#(1)(5)(8)#
+8map_values(8map(8equal,(1,2)(8add(2,3),10)(8,20)))#(2)(10)(20)#
+8map_items(8map_union(8map(8equal,(1,2)(3,4)(5,6)),8map(8equal,(1,22)(3,44)(5,66)(7, 88))))#((1,2))((3,4))((5,6))((7,88))#
+8map_items(8map_intersect(8map(8equal,(0,0)(1,2)(3,4)(5,6)),8map(8equal,(1,22)(3,44)(5,66)(7, 88))))#((1,2))((3,4))((5,6))#
+8map_items(8map_symm_diff(8map(8equal,(0,0)(1,2)(3,4)(5,6)),8map(8equal,(1,22)(3,44)(5,66)(7, 88))))#((7,88))((0,0))#


### PR DESCRIPTION
I've been using Order a lot lately, so I figured it would be good to contribute back a little. This implements a map/dict/associative array datastructure modeled as a lisp-style association list, and uses a user-provided binary predicate to compare keys.

Functions added:
 - 8map(<cmp_fn>, (<key>, <value>)+): construct a map with 0 or more elements

 - 8map_items(map): gets the map items as a seq of pairs
 - 8map_keys(map): gets the map keys as a seq
 - 8map_values(map): gets the map values as a seq

 - 8map_at(key, map): gets the value associated with the key, or nil if not present
 - 8map_exists(key, map): returns true if the key exists in the map, else false
 - 8map_insert(key, value, map): inserts the given entry into the map if not present, otherwise replaces the value at the key
 - 8map_replace(key, value, map): replaces the value for the given key if it is present
 - 8map_erase(key, map): erases the entry for the given key if it is present
 - 8map_size(map): gets the size of the map as a nat

 - 8map_union(map1, map2): adds all entries in map2 to map1
 - 8map_intersect(map1, map2): gets all map entries that are common to both map1 and map2
 - 8map_diff(map1, map2): removes all entries in map2 from map1
 - 8map_symm_diff(map1, map2): gets all map entries that are not common to both map1 and map2

 - 8map_equivalence_fn(map): get the equality function for the map

It's possible to support a second "compare" function (or more realistically, some "to_int" function since noting else is easily comparable) to build a tree-like structure for faster operations, but I haven't gotten that far yet.